### PR TITLE
FIX - protected method `ActivceRecord::Relation#load_records` call

### DIFF
--- a/lib/octopus/relation_proxy.rb
+++ b/lib/octopus/relation_proxy.rb
@@ -24,7 +24,13 @@ module Octopus
       if block
         @ar_relation.public_send(method, *args, &block)
       else
-        run_on_shard { @ar_relation.public_send(method, *args) }
+        run_on_shard do
+          if method == :load_records
+            @ar_relation.send(method, *args)
+          else
+            @ar_relation.public_send(method, *args)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### 이유
- Rails 5에서 `ActivceRecord::Relation#load_records`가 protected method로 변경됨.

참고: https://github.com/thiagopradi/octopus/blob/1c9a07fd9f663a33b7298297a10e10c8b37cd648/lib/octopus/relation_proxy.rb#L36

Signed-off-by: Hansuk Hong <flavono123@gmail.com>